### PR TITLE
fix memory leak on each call

### DIFF
--- a/mswasapi_writer.cpp
+++ b/mswasapi_writer.cpp
@@ -214,6 +214,7 @@ error:
 int MSWASAPIWriter::deactivate()
 {
 	RELEASE_CLIENT(mAudioRenderClient);
+	RELEASE_CLIENT(mVolumeControler);
 	mIsActivated = false;
 	return 0;
 }


### PR DESCRIPTION
When testing 5.2.x on windows 7 or windows 10, I found memory leaking on each call, which cause the memory of process audiodg.exe to increase slowly, from 10MB to 40MB. After 180 or more calls, mAudioClient->Initialize() fails with result code 8890017 or 8007000e. If continue with calling, linphone may crash finally. The modified code fixed the memory leak problem. After fixing, 2000 calls do not increase the audiodg.exe memory more than 1MB, and no failing result code when mAudioClient->Initialize().